### PR TITLE
Add Sail CI file for new platform

### DIFF
--- a/.sail.yml
+++ b/.sail.yml
@@ -1,0 +1,9 @@
+tasks:
+  install:
+    image: "node:10-alpine"
+    command: ["yarn"]
+    args: ["install"]
+  test:
+    image: "node:10-alpine"
+    command: ["yarn"]
+    args: ["test"]


### PR DESCRIPTION
Hi, thanks for trying out Sail CI ⛵️. We've listened to feedback and since improved and updated everything. It now installs seamlessly as a GitHub App and you can read more about it here - https://sail.ci/blog/new-sail-ci-platform-open-alpha. The main benefits are:

* Use Docker containers as "tasks" for your pipeline
* Use GitHub's new Checks feature within PRs for realtime logs and feedback
* Now builds PRs raised from forks

We'd like to move everyone across to the new platform and I've prepared a new `.sail.yml` file for you based on your previous one. All you need to do is install Sail CI via this link - 
https://github.com/apps/sail-ci-alpha/installations/new - and then merge this PR. Afterwards, you can delete the old `.sail` file and remove the deploy key and webhook.

We'd love to hear any feedback and you can get in touch with us on [Spectrum](https://spectrum.chat/sail-ci).

🎉 